### PR TITLE
added to secHeaders and added userns remap to docker were missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ docker_traefik_enable_stored_certs: false
 docker_traefik_enable_acme: false
 docker_traefik_enable_headers: false
 docker_traefik_enable_compression: false
+docker_traefik_secHeaders_custom_frame_option_allow_same_origin: true
 docker_traefik_ports: []
 docker_traefik_additional_entrypoints: [{
   name: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,7 @@ docker_traefik_dns_challenge: false
 docker_traefik_dns_provider: ""
 docker_traefik_dns_resolvers: []
 docker_traefik_dns_delay: "20"
+docker_traefik_secHeaders_custom_frame_option_allow_same_origin: false
 # -- watchtower -----------------
 watchtower_poll_interval: "3600"
 watchtower_schedule: ""

--- a/tasks/docker-portainer-agent.yml
+++ b/tasks/docker-portainer-agent.yml
@@ -21,6 +21,7 @@
   community.docker.docker_container:
     name: portainer-agent
     image: portainer/agent:{{ docker_portainer_version }}
+    userns_mode: "host"
     pull: true
     restart_policy: always
     security_opts:

--- a/tasks/docker-traefik.yml
+++ b/tasks/docker-traefik.yml
@@ -95,6 +95,7 @@
     owner: "{{ docker_traefik_dynamic_user }}"
     group: "{{ docker_traefik_dynamic_group }}"
     mode: "0644"
+  diff: true
 
 - name: Generate and copy additional non docker services
   ansible.builtin.template:

--- a/templates/traefik/default.yml.j2
+++ b/templates/traefik/default.yml.j2
@@ -30,6 +30,9 @@ http:
         browserXssFilter: true
         contentTypeNosniff: true
         frameDeny: {{ (docker_traefik_secHeaders_custom_frame_deny | default('true')) | bool }}
+{% if docker_traefik_secHeaders_custom_frame_option_allow_same_origin | bool %}
+        customFrameOptionsValue: 'sameorigin'
+{% endif %}
         referrerPolicy: "{{ docker_traefik_secHeaders_referrer_policy | default('same-origin') }}"
         # Content-Security-Policy
         #        contentSecurityPolicy: "{{ docker_traefik_secHeaders_content_security_policy | default('default-src \'self\'') }}"


### PR DESCRIPTION
As discussed.  

`customFrameOption: same-origin` was needed for certain stacks.  

and portainer needs to run in host namespace if one chooses the security option as suggested in our docker role  