### PR TITLE
remove trailing comma in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,5 +31,5 @@
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     }
-  ],
+  ]
 }


### PR DESCRIPTION
## Issue:  

![image](https://github.com/user-attachments/assets/678f7c26-ec49-4717-8dbe-baaba5c591c3)

## Reason:   

![image](https://github.com/user-attachments/assets/eb564547-4a20-419a-a5fe-7d678736f037)
