### PR TITLE
Add github action to publish to ansible galaxy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 ---
 # copied from https://github.com/geerlingguy/ansible-role-docker/blob/master/.github/workflows/release.yml
-# 
+#
 # This workflow requires a GALAXY_API_KEY secret present in the GitHub
 # repository or organization.
 #


### PR DESCRIPTION
Added a github action to automaticly release to ansible galaxy whenever a new tag is added.  
mostly stolen from geerlinguys ansible role docker.  
Added secret to pipeline   