### PR TITLE
bind portainer agent & treafik ports to interfaces

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,9 +10,11 @@ docker_portainer_image: portainer/portainer-ce
 docker_portainer_version: "2.33.2"
 docker_portainer_parameter: "" # e.g.--logo
 docker_portainer_healthcheck: {}  # See README
+docker_portainer_ip_address: "0.0.0.0"
 # -- traefik -------------------
 # renovate: depName=traefik
 docker_traefik_version: "v3.6.2"
+docker_traefik_ip_address: "0.0.0.0"
 docker_traefik_custom_environment: {}
 docker_traefik_path: "/opt/traefik"
 docker_traefik_network_name: "proxy"

--- a/tasks/docker-portainer-agent.yml
+++ b/tasks/docker-portainer-agent.yml
@@ -9,7 +9,7 @@
     security_opts:
       - no-new-privileges:true
     ports:
-      - 9001:9001
+      - "{{ docker_portainer_ip_address }}:9001:9001"
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/var/run/docker.sock

--- a/tasks/docker-traefik.yml
+++ b/tasks/docker-traefik.yml
@@ -34,7 +34,8 @@
 
 - name: Add traefik endpoint ports
   ansible.builtin.set_fact:
-    docker_traefik_ports: "{{ docker_traefik_ports + ['80:80', '443:443'] }}"
+    docker_traefik_ports: "{{ docker_traefik_ports
+      + [docker_traefik_ip_address + ':80:80', docker_traefik_ip_address + ':443:443'] }}"
     # ToDo: use Variables for traefik endpoint ports
 
 - name: Merge docker_traefik_ports and docker_traefik_additional_entrypoints


### PR DESCRIPTION
As mentioned elsewhere I have added interface IP addresses to traefik and portainer-agent to be able to restrict access to only e.g. a LAN interface.  

I've set `0.0.0.0` as the default as this is what was implied before.  

