### PR TITLE
watchtower add new security delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Depending on what loadout you wanna achieve:
           - smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes
         docker_watchtower_disabled_containers_list:
           - myservice
+        docker_watchtower_cooldown_delay: 0  # disable security cooldown
       roles:
         - ansible_role_docker_stack
 ```
@@ -193,6 +194,7 @@ docker_watchtower_disabled_containers_list: []  # Regex patterns are supported
 docker_watchtower_log_level: info  # panic, fatal, error, warn, info, debug, trace
 docker_watchtower_log_format: Auto  # Auto, LogFmt, Pretty, JSON
 docker_watchtower_rolling_restart: false
+docker_watchtower_cooldown_delay: 12h
 
 ############
 # Metrics  #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,5 +60,6 @@ docker_watchtower_disabled_containers_list: []  # Regex patterns are supported
 docker_watchtower_log_level: info  # panic, fatal, error, warn, info, debug, trace
 docker_watchtower_log_format: Auto  # Auto, LogFmt, Pretty, JSON
 docker_watchtower_rolling_restart: false
+docker_watchtower_cooldown_delay: 12h
 # --
 docker_logins: []

--- a/templates/watchtower_env.j2
+++ b/templates/watchtower_env.j2
@@ -11,6 +11,7 @@ WATCHTOWER_SCHEDULE={{ docker_watchtower_schedule }}
 {% if docker_watchtower_poll_interval | length %}
 WATCHTOWER_POLL_INTERVAL={{ docker_watchtower_poll_interval }}
 {% endif %}
+WATCHTOWER_COOLDOWN_DELAY={{ docker_watchtower_cooldown_delay }}
 WATCHTOWER_INCLUDE_STOPPED=false
 WATCHTOWER_REVIVE_STOPPED=false
 WATCHTOWER_INCLUDE_RESTARTING=false


### PR DESCRIPTION
See docs: https://watchtower.nickfedor.com/v1.16.1/advanced-features/image-cooldown/  

Motivateted by the recent supply chain issues this PR adds a 12h cooldown to watchtower.  
i.e. watchtower only updates to images older than 12h.  

var: `docker_watchtower_cooldown_delay`  